### PR TITLE
Reproduce issue with Report Description showing at the bottom of the …

### DIFF
--- a/01-GettingStarted/client/html/index.html
+++ b/01-GettingStarted/client/html/index.html
@@ -6,7 +6,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Reveal Sdk - Web Component</title>      
-
+    <style>
+      body > pre {
+        padding: 9.5px;
+      }
+    </style>
 </head>
 
 <body>
@@ -14,7 +18,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.6.1/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.6.6/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
         //set this to your server url


### PR DESCRIPTION
This should not be accepted, it's an example contribution to this repo that illustrates how to reproduce an issue I'm submitting a Bug report on.  The issue is that the Report's description field shows at the bottom of the page if the user of the reveal sdk has global styles on the `<pre>` element that do things like setting padding.  This element appears to be a template element that is cloned into a dashboard when it enters edit mode.