### PR TITLE
Updated Databricks sample to use RVPersonalAccessTokenDataSourceCredential.

### DIFF
--- a/DataSources/Databricks/server/aspnet/RevealSdk.Server/Reveal/AuthenticationProvider.cs
+++ b/DataSources/Databricks/server/aspnet/RevealSdk.Server/Reveal/AuthenticationProvider.cs
@@ -13,7 +13,7 @@ namespace RevealSdk.Server.Reveal
             if (dataSource is RVDatabricksDataSource)
             {
                 userCredential =
-                    new RVBearerTokenDataSourceCredential("your_personal_access_token", "your_userid");
+                    new RVPersonalAccessTokenDataSourceCredential("your_personal_access_token");
             }
 
             return Task.FromResult(userCredential);

--- a/DataSources/Databricks/server/nodejs-js/main.js
+++ b/DataSources/Databricks/server/nodejs-js/main.js
@@ -22,7 +22,7 @@ const userContextProvider = (request) => {
 // Step 2: Authentication
 const authenticationProvider = async (userContext, dataSource) => {
 	if (dataSource instanceof reveal.RVDatabricksDataSource) {
-		return new reveal.RVBearerTokenDataSourceCredential("your_personal_access_token", "your_userid");
+		return new reveal.RVPersonalAccessTokenDataSourceCredential("your_personal_access_token");
     }
 	return null;
 }

--- a/DataSources/Databricks/server/nodejs-ts/src/app.ts
+++ b/DataSources/Databricks/server/nodejs-ts/src/app.ts
@@ -7,7 +7,7 @@ import reveal,
     RVDataSourceItem,
     RVDatabricksDataSource,
     RVDatabricksDataSourceItem,
-    RVBearerTokenDataSourceCredential
+    RVPersonalAccessTokenDataSourceCredential
 } from 'reveal-sdk-node';
 import cors from "cors";
 
@@ -17,7 +17,7 @@ app.use(cors());
 
 const authenticationProvider = async (userContext: IRVUserContext | null, dataSource: RVDashboardDataSource) => {
     if (dataSource instanceof RVDatabricksDataSource) {
-        return new RVBearerTokenDataSourceCredential("your_personal_access_token", "your_userid");
+        return new RVPersonalAccessTokenDataSourceCredential("your_personal_access_token");
     }
     return null;
 }

--- a/DataSources/Databricks/server/spring-boot-jersey/src/main/java/com/server/reveal/AuthenticationProvider.java
+++ b/DataSources/Databricks/server/spring-boot-jersey/src/main/java/com/server/reveal/AuthenticationProvider.java
@@ -3,7 +3,7 @@ package com.server.reveal;
 import com.infragistics.reveal.sdk.api.IRVAuthenticationProvider;
 import com.infragistics.reveal.sdk.api.IRVDataSourceCredential;
 import com.infragistics.reveal.sdk.api.IRVUserContext;
-import com.infragistics.reveal.sdk.api.RVBearerTokenDataSourceCredential;
+import com.infragistics.reveal.sdk.api.RVPersonalAccessTokenDataSourceCredential;
 import com.infragistics.reveal.sdk.api.model.RVDashboardDataSource;
 import com.infragistics.reveal.sdk.api.model.RVDatabricksDataSource;
 
@@ -11,7 +11,7 @@ public class AuthenticationProvider implements IRVAuthenticationProvider {
 	@Override
 	public IRVDataSourceCredential resolveCredentials(IRVUserContext userContext, RVDashboardDataSource dataSource) {
         if (dataSource instanceof RVDatabricksDataSource) {
-			return new RVBearerTokenDataSourceCredential("your_personal_access_token", "your_userid");
+			return new RVPersonalAccessTokenDataSourceCredential("your_personal_access_token");
 		} 
 		return null;
 	}


### PR DESCRIPTION
Updated Databricks sample authentication provider to use RVPersonalAccessTokenDataSourceCredential instead of bearer token.