### PR TITLE
Updates Reveal SDK version to 1.8.3

### DIFF
--- a/01-GettingStarted/client/angular/src/index.html
+++ b/01-GettingStarted/client/angular/src/index.html
@@ -13,6 +13,6 @@
   <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
   <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
   
-  <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+  <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 </body>
 </html>

--- a/01-GettingStarted/client/aspnet-webapp/GettingStarted/GettingStarted.csproj
+++ b/01-GettingStarted/client/aspnet-webapp/GettingStarted/GettingStarted.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
   </ItemGroup>
 
 </Project>

--- a/01-GettingStarted/client/aspnet-webapp/GettingStarted/Pages/Shared/_Layout.cshtml
+++ b/01-GettingStarted/client/aspnet-webapp/GettingStarted/Pages/Shared/_Layout.cshtml
@@ -49,7 +49,7 @@
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
     
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     @await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/01-GettingStarted/client/html/index.html
+++ b/01-GettingStarted/client/html/index.html
@@ -14,7 +14,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
         //set this to your server url

--- a/01-GettingStarted/client/react/public/index.html
+++ b/01-GettingStarted/client/react/public/index.html
@@ -43,6 +43,6 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
     
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
   </body>
 </html>

--- a/01-GettingStarted/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/01-GettingStarted/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/01-GettingStarted/server/nest/package-lock.json
+++ b/01-GettingStarted/server/nest/package-lock.json
@@ -13,7 +13,7 @@
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
         "reflect-metadata": "^0.2.0",
-        "reveal-sdk-node": "^1.7.2",
+        "reveal-sdk-node": "^1.8.3",
         "rxjs": "^7.8.1"
       },
       "devDependencies": {

--- a/01-GettingStarted/server/nest/package.json
+++ b/01-GettingStarted/server/nest/package.json
@@ -24,7 +24,7 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "reflect-metadata": "^0.2.0",
-    "reveal-sdk-node": "^1.7.2",
+    "reveal-sdk-node": "^1.8.3",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {

--- a/01-GettingStarted/server/nodejs-js/package-lock.json
+++ b/01-GettingStarted/server/nodejs-js/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       }
     },
     "node_modules/@types/node": {

--- a/01-GettingStarted/server/nodejs-js/package.json
+++ b/01-GettingStarted/server/nodejs-js/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   }
 }

--- a/01-GettingStarted/server/nodejs-ts/package-lock.json
+++ b/01-GettingStarted/server/nodejs-ts/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/01-GettingStarted/server/nodejs-ts/package.json
+++ b/01-GettingStarted/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/01-GettingStarted/server/spring-boot-jersey/pom.xml
+++ b/01-GettingStarted/server/spring-boot-jersey/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.infragistics.reveal.sdk</groupId>
 			<artifactId>reveal-sdk</artifactId>
-			<version>1.7.2</version>
+			<version>1.8.3</version>
 		</dependency>
 		
 	</dependencies>

--- a/ChartTypes/index.html
+++ b/ChartTypes/index.html
@@ -13,7 +13,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">        
         //set this to your server url

--- a/CustomDataSourceSelectionDialog/index.html
+++ b/CustomDataSourceSelectionDialog/index.html
@@ -38,7 +38,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         $.ig.RevealSdkSettings.setBaseUrl("https://samples.revealbi.io/upmedia-backend/reveal-api/");

--- a/CustomMenuItems/index.html
+++ b/CustomMenuItems/index.html
@@ -22,7 +22,7 @@
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
 
 <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-<script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+<script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
 <script type="text/javascript">
     //set this to your server url

--- a/CustomQueries/client/index.html
+++ b/CustomQueries/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         $.ig.RevealSdkSettings.setBaseUrl("http://localhost:5111/");

--- a/CustomQueries/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/CustomQueries/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
-    <PackageReference Include="Reveal.Sdk.Data.Microsoft.SqlServer" Version="1.7.2" />
-    <PackageReference Include="Reveal.Sdk.Data.MySql" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
+    <PackageReference Include="Reveal.Sdk.Data.Microsoft.SqlServer" Version="1.8.3" />
+    <PackageReference Include="Reveal.Sdk.Data.MySql" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/CustomQueries/server/nodejs-js/package-lock.json
+++ b/CustomQueries/server/nodejs-js/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       }
     },
     "node_modules/@types/node": {

--- a/CustomQueries/server/nodejs-js/package.json
+++ b/CustomQueries/server/nodejs-js/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   }
 }

--- a/CustomQueries/server/nodejs-ts/package-lock.json
+++ b/CustomQueries/server/nodejs-ts/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/CustomQueries/server/nodejs-ts/package.json
+++ b/CustomQueries/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/CustomQueries/server/spring-boot-jersey/pom.xml
+++ b/CustomQueries/server/spring-boot-jersey/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.infragistics.reveal.sdk</groupId>
 			<artifactId>reveal-sdk</artifactId>
-			<version>1.7.2</version>
+			<version>1.8.3</version>
 		</dependency>
 		
 	</dependencies>

--- a/CustomVisualization/client/angular/src/index.html
+++ b/CustomVisualization/client/angular/src/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
   
   <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-  <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+  <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
   <script src="./assets/reveal/reveal.bridge.js"></script>
 </body>
 </html>

--- a/CustomVisualization/client/react/public/index.html
+++ b/CustomVisualization/client/react/public/index.html
@@ -43,7 +43,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
     
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
     <script src="./assets/reveal/reveal.bridge.js"></script>
   </body>
 </html>

--- a/CustomVisualization/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/CustomVisualization/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 

--- a/CustomVisualization/server/nodejs-ts/package-lock.json
+++ b/CustomVisualization/server/nodejs-ts/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/CustomVisualization/server/nodejs-ts/package.json
+++ b/CustomVisualization/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/CustomizingMapTiles/client/index.html
+++ b/CustomizingMapTiles/client/index.html
@@ -13,7 +13,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
 <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-<script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+<script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
 <script type="text/javascript">
     // set this to your server url

--- a/CustomizingMapTiles/server/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/CustomizingMapTiles/server/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/DataSources/Amazon-Athena/client/index.html
+++ b/DataSources/Amazon-Athena/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         $.ig.RevealSdkSettings.setBaseUrl("http://localhost:5111/");

--- a/DataSources/Amazon-Athena/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/DataSources/Amazon-Athena/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
-    <PackageReference Include="Reveal.Sdk.Data.Amazon.Athena" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
+    <PackageReference Include="Reveal.Sdk.Data.Amazon.Athena" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/DataSources/Amazon-Athena/server/nodejs-js/package-lock.json
+++ b/DataSources/Amazon-Athena/server/nodejs-js/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       }
     },
     "node_modules/@types/node": {

--- a/DataSources/Amazon-Athena/server/nodejs-js/package.json
+++ b/DataSources/Amazon-Athena/server/nodejs-js/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   }
 }

--- a/DataSources/Amazon-Athena/server/nodejs-ts/package-lock.json
+++ b/DataSources/Amazon-Athena/server/nodejs-ts/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/DataSources/Amazon-Athena/server/nodejs-ts/package.json
+++ b/DataSources/Amazon-Athena/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/DataSources/Amazon-Athena/server/spring-boot-jersey/pom.xml
+++ b/DataSources/Amazon-Athena/server/spring-boot-jersey/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.infragistics.reveal.sdk</groupId>
 			<artifactId>reveal-sdk</artifactId>
-			<version>1.7.2</version>
+			<version>1.8.3</version>
 		</dependency>
 		
 	</dependencies>

--- a/DataSources/Amazon-S3/client/index.html
+++ b/DataSources/Amazon-S3/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         $.ig.RevealSdkSettings.setBaseUrl("http://localhost:5111/");

--- a/DataSources/Amazon-S3/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/DataSources/Amazon-S3/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
-    <PackageReference Include="Reveal.Sdk.Data.Amazon.S3" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
+    <PackageReference Include="Reveal.Sdk.Data.Amazon.S3" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/DataSources/Amazon-S3/server/nodejs-js/package-lock.json
+++ b/DataSources/Amazon-S3/server/nodejs-js/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       }
     },
     "node_modules/@types/node": {

--- a/DataSources/Amazon-S3/server/nodejs-js/package.json
+++ b/DataSources/Amazon-S3/server/nodejs-js/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   }
 }

--- a/DataSources/Amazon-S3/server/nodejs-ts/package-lock.json
+++ b/DataSources/Amazon-S3/server/nodejs-ts/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/DataSources/Amazon-S3/server/nodejs-ts/package.json
+++ b/DataSources/Amazon-S3/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/DataSources/Amazon-S3/server/spring-boot-jersey/pom.xml
+++ b/DataSources/Amazon-S3/server/spring-boot-jersey/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.infragistics.reveal.sdk</groupId>
 			<artifactId>reveal-sdk</artifactId>
-			<version>1.7.2</version>
+			<version>1.8.3</version>
 		</dependency>
 		
 	</dependencies>

--- a/DataSources/BigQuery-ServiceAccount/client/index.html
+++ b/DataSources/BigQuery-ServiceAccount/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         $.ig.RevealSdkSettings.setBaseUrl("http://localhost:5111/");

--- a/DataSources/BigQuery-ServiceAccount/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/DataSources/BigQuery-ServiceAccount/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Apis.Auth.AspNetCore3" Version="1.59.0" />
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
-    <PackageReference Include="Reveal.Sdk.Data.Google.BigQuery" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
+    <PackageReference Include="Reveal.Sdk.Data.Google.BigQuery" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/DataSources/BigQuery-ServiceAccount/server/nodejs-js/package-lock.json
+++ b/DataSources/BigQuery-ServiceAccount/server/nodejs-js/package-lock.json
@@ -12,7 +12,7 @@
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "google-auth-library": "^8.7.0",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       }
     },
     "node_modules/@types/node": {

--- a/DataSources/BigQuery-ServiceAccount/server/nodejs-js/package.json
+++ b/DataSources/BigQuery-ServiceAccount/server/nodejs-js/package.json
@@ -14,6 +14,6 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "google-auth-library": "^8.7.0",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   }
 }

--- a/DataSources/BigQuery-ServiceAccount/server/nodejs-ts/package-lock.json
+++ b/DataSources/BigQuery-ServiceAccount/server/nodejs-ts/package-lock.json
@@ -12,7 +12,7 @@
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "google-auth-library": "^8.7.0",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/DataSources/BigQuery-ServiceAccount/server/nodejs-ts/package.json
+++ b/DataSources/BigQuery-ServiceAccount/server/nodejs-ts/package.json
@@ -15,7 +15,7 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "google-auth-library": "^8.7.0",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/DataSources/Csv/index.html
+++ b/DataSources/Csv/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
     
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
         $.ig.RevealSdkSettings.setBaseUrl("https://samples.revealbi.io/upmedia-backend/reveal-api/");

--- a/DataSources/ExcelFile/client/index.html
+++ b/DataSources/ExcelFile/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
     
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
 

--- a/DataSources/ExcelFile/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/DataSources/ExcelFile/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/DataSources/ExcelFile/server/nodejs-js/package-lock.json
+++ b/DataSources/ExcelFile/server/nodejs-js/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       }
     },
     "node_modules/@types/node": {

--- a/DataSources/ExcelFile/server/nodejs-js/package.json
+++ b/DataSources/ExcelFile/server/nodejs-js/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   }
 }

--- a/DataSources/ExcelFile/server/nodejs-ts/package-lock.json
+++ b/DataSources/ExcelFile/server/nodejs-ts/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/DataSources/ExcelFile/server/nodejs-ts/package.json
+++ b/DataSources/ExcelFile/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/DataSources/ExcelFile/server/spring-boot-jersey/pom.xml
+++ b/DataSources/ExcelFile/server/spring-boot-jersey/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.infragistics.reveal.sdk</groupId>
 			<artifactId>reveal-sdk</artifactId>
-			<version>1.7.2</version>
+			<version>1.8.3</version>
 		</dependency>
 		
 	</dependencies>

--- a/DataSources/GoogleDrive-ServiceAccount/client/index.html
+++ b/DataSources/GoogleDrive-ServiceAccount/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         $.ig.RevealSdkSettings.setBaseUrl("http://localhost:5111/");

--- a/DataSources/GoogleDrive-ServiceAccount/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/DataSources/GoogleDrive-ServiceAccount/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Apis.Auth.AspNetCore3" Version="1.59.0" />
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
-    <PackageReference Include="Reveal.Sdk.Data.Google.Drive" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
+    <PackageReference Include="Reveal.Sdk.Data.Google.Drive" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/DataSources/GoogleDrive-ServiceAccount/server/nodejs-js/package-lock.json
+++ b/DataSources/GoogleDrive-ServiceAccount/server/nodejs-js/package-lock.json
@@ -12,7 +12,7 @@
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "google-auth-library": "^8.7.0",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       }
     },
     "node_modules/@types/node": {

--- a/DataSources/GoogleDrive-ServiceAccount/server/nodejs-js/package.json
+++ b/DataSources/GoogleDrive-ServiceAccount/server/nodejs-js/package.json
@@ -14,6 +14,6 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "google-auth-library": "^8.7.0",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   }
 }

--- a/DataSources/GoogleDrive-ServiceAccount/server/nodejs-ts/package-lock.json
+++ b/DataSources/GoogleDrive-ServiceAccount/server/nodejs-ts/package-lock.json
@@ -12,7 +12,7 @@
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "google-auth-library": "^8.7.0",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/DataSources/GoogleDrive-ServiceAccount/server/nodejs-ts/package.json
+++ b/DataSources/GoogleDrive-ServiceAccount/server/nodejs-ts/package.json
@@ -15,7 +15,7 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "google-auth-library": "^8.7.0",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/DataSources/GoogleSheets-ServiceAccount/client/index.html
+++ b/DataSources/GoogleSheets-ServiceAccount/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         $.ig.RevealSdkSettings.setBaseUrl("http://localhost:5111/");

--- a/DataSources/GoogleSheets-ServiceAccount/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/DataSources/GoogleSheets-ServiceAccount/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Apis.Auth.AspNetCore3" Version="1.59.0" />
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
-    <PackageReference Include="Reveal.Sdk.Data.Google.Drive" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
+    <PackageReference Include="Reveal.Sdk.Data.Google.Drive" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/DataSources/GoogleSheets-ServiceAccount/server/nodejs-js/package-lock.json
+++ b/DataSources/GoogleSheets-ServiceAccount/server/nodejs-js/package-lock.json
@@ -12,7 +12,7 @@
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "google-auth-library": "^8.7.0",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       }
     },
     "node_modules/@types/node": {

--- a/DataSources/GoogleSheets-ServiceAccount/server/nodejs-js/package.json
+++ b/DataSources/GoogleSheets-ServiceAccount/server/nodejs-js/package.json
@@ -14,6 +14,6 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "google-auth-library": "^8.7.0",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   }
 }

--- a/DataSources/GoogleSheets-ServiceAccount/server/nodejs-ts/package-lock.json
+++ b/DataSources/GoogleSheets-ServiceAccount/server/nodejs-ts/package-lock.json
@@ -12,7 +12,7 @@
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "google-auth-library": "^8.7.0",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/DataSources/GoogleSheets-ServiceAccount/server/nodejs-ts/package.json
+++ b/DataSources/GoogleSheets-ServiceAccount/server/nodejs-ts/package.json
@@ -15,7 +15,7 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "google-auth-library": "^8.7.0",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/DataSources/InMemory/client/index.html
+++ b/DataSources/InMemory/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         

--- a/DataSources/InMemory/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/DataSources/InMemory/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/DataSources/Json/index.html
+++ b/DataSources/Json/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         $.ig.RevealSdkSettings.setBaseUrl("https://samples.revealbi.io/upmedia-backend/reveal-api/");

--- a/DataSources/MicrosoftAnalysisServices/client/index.html
+++ b/DataSources/MicrosoftAnalysisServices/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         $.ig.RevealSdkSettings.setBaseUrl("http://localhost:5111/");

--- a/DataSources/MicrosoftAnalysisServices/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/DataSources/MicrosoftAnalysisServices/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
-    <PackageReference Include="Reveal.Sdk.Data.Microsoft.AnalysisServices" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
+    <PackageReference Include="Reveal.Sdk.Data.Microsoft.AnalysisServices" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/DataSources/MongoDB/client/index.html
+++ b/DataSources/MongoDB/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         $.ig.RevealSdkSettings.setBaseUrl("http://localhost:5111/");

--- a/DataSources/MongoDB/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/DataSources/MongoDB/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
-    <PackageReference Include="Reveal.Sdk.Data.MongoDB" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
+    <PackageReference Include="Reveal.Sdk.Data.MongoDB" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/DataSources/MongoDB/server/nodejs-js/package-lock.json
+++ b/DataSources/MongoDB/server/nodejs-js/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       }
     },
     "node_modules/@types/node": {

--- a/DataSources/MongoDB/server/nodejs-js/package.json
+++ b/DataSources/MongoDB/server/nodejs-js/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   }
 }

--- a/DataSources/MsSqlServer/client/index.html
+++ b/DataSources/MsSqlServer/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>     
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>     
 
     <script type="text/javascript">
         $.ig.RevealSdkSettings.setBaseUrl("http://localhost:5111/");

--- a/DataSources/MsSqlServer/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/DataSources/MsSqlServer/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
-    <PackageReference Include="Reveal.Sdk.Data.Microsoft.SqlServer" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
+    <PackageReference Include="Reveal.Sdk.Data.Microsoft.SqlServer" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/DataSources/MsSqlServer/server/nodejs-js/package-lock.json
+++ b/DataSources/MsSqlServer/server/nodejs-js/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       }
     },
     "node_modules/@types/node": {

--- a/DataSources/MsSqlServer/server/nodejs-js/package.json
+++ b/DataSources/MsSqlServer/server/nodejs-js/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   }
 }

--- a/DataSources/MsSqlServer/server/nodejs-ts/package-lock.json
+++ b/DataSources/MsSqlServer/server/nodejs-ts/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/DataSources/MsSqlServer/server/nodejs-ts/package.json
+++ b/DataSources/MsSqlServer/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/DataSources/MsSqlServer/server/spring-boot-jersey/pom.xml
+++ b/DataSources/MsSqlServer/server/spring-boot-jersey/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.infragistics.reveal.sdk</groupId>
 			<artifactId>reveal-sdk</artifactId>
-			<version>1.7.2</version>
+			<version>1.8.3</version>
 		</dependency>
 		
 	</dependencies>

--- a/DataSources/MySQL/client/index.html
+++ b/DataSources/MySQL/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         $.ig.RevealSdkSettings.setBaseUrl("http://localhost:5111/");

--- a/DataSources/MySQL/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/DataSources/MySQL/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
-    <PackageReference Include="Reveal.Sdk.Data.MySql" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
+    <PackageReference Include="Reveal.Sdk.Data.MySql" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/DataSources/MySQL/server/nodejs-ts/package.json
+++ b/DataSources/MySQL/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/DataSources/MySQL/server/spring-boot-jersey/pom.xml
+++ b/DataSources/MySQL/server/spring-boot-jersey/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.infragistics.reveal.sdk</groupId>
 			<artifactId>reveal-sdk</artifactId>
-			<version>1.7.2</version>
+			<version>1.8.3</version>
 		</dependency>
 		
 	</dependencies>

--- a/DataSources/Oracle/client/index.html
+++ b/DataSources/Oracle/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
         $.ig.RevealSdkSettings.setBaseUrl("http://localhost:5111/");

--- a/DataSources/Oracle/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/DataSources/Oracle/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
-    <PackageReference Include="Reveal.Sdk.Data.Oracle" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
+    <PackageReference Include="Reveal.Sdk.Data.Oracle" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/DataSources/Oracle/server/nodejs-ts/package-lock.json
+++ b/DataSources/Oracle/server/nodejs-ts/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/DataSources/Oracle/server/nodejs-ts/package.json
+++ b/DataSources/Oracle/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/DataSources/Oracle/server/spring-boot-jersey/pom.xml
+++ b/DataSources/Oracle/server/spring-boot-jersey/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.infragistics.reveal.sdk</groupId>
 			<artifactId>reveal-sdk</artifactId>
-			<version>1.7.2</version>
+			<version>1.8.3</version>
 		</dependency>
 
 		<dependency>

--- a/DataSources/PostgreSQL/client/index.html
+++ b/DataSources/PostgreSQL/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         $.ig.RevealSdkSettings.setBaseUrl("http://localhost:5111/");

--- a/DataSources/PostgreSQL/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/DataSources/PostgreSQL/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
-    <PackageReference Include="Reveal.Sdk.Data.PostgreSQL" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
+    <PackageReference Include="Reveal.Sdk.Data.PostgreSQL" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/DataSources/PostgreSQL/server/nodejs-ts/package.json
+++ b/DataSources/PostgreSQL/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/DataSources/PostgreSQL/server/spring-boot-jersey/pom.xml
+++ b/DataSources/PostgreSQL/server/spring-boot-jersey/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.infragistics.reveal.sdk</groupId>
 			<artifactId>reveal-sdk</artifactId>
-			<version>1.7.2</version>
+			<version>1.8.3</version>
 		</dependency>
 		
 	</dependencies>

--- a/DataSources/RestService/index.html
+++ b/DataSources/RestService/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         $.ig.RevealSdkSettings.setBaseUrl("https://samples.revealbi.io/upmedia-backend/reveal-api/");

--- a/DataSources/Snowflake/client/index.html
+++ b/DataSources/Snowflake/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         $.ig.RevealSdkSettings.setBaseUrl("http://localhost:5111/");

--- a/DataSources/Snowflake/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/DataSources/Snowflake/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
-    <PackageReference Include="Reveal.Sdk.Data.Snowflake" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
+    <PackageReference Include="Reveal.Sdk.Data.Snowflake" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/DataSources/Snowflake/server/nodejs-ts/package.json
+++ b/DataSources/Snowflake/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/DataSources/Snowflake/server/spring-boot-jersey/pom.xml
+++ b/DataSources/Snowflake/server/spring-boot-jersey/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.infragistics.reveal.sdk</groupId>
 			<artifactId>reveal-sdk</artifactId>
-			<version>1.7.2</version>
+			<version>1.8.3</version>
 		</dependency>
 		
 	</dependencies>

--- a/Exporting-Image/index.html
+++ b/Exporting-Image/index.html
@@ -23,7 +23,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
     
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
         //set this to your server url

--- a/Exporting-Server/client/index.html
+++ b/Exporting-Server/client/index.html
@@ -18,7 +18,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
         //set this to your server url

--- a/Exporting-Server/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/Exporting-Server/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/Exporting-Server/server/nodejs-ts/package-lock.json
+++ b/Exporting-Server/server/nodejs-ts/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/Exporting-Server/server/nodejs-ts/package.json
+++ b/Exporting-Server/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/Exporting-Server/server/spring-boot-jersey/pom.xml
+++ b/Exporting-Server/server/spring-boot-jersey/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.infragistics.reveal.sdk</groupId>
 			<artifactId>reveal-sdk</artifactId>
-			<version>1.7.2</version>
+			<version>1.8.3</version>
 		</dependency>
 		
 	</dependencies>

--- a/FilteringDashboards-Dates/index.html
+++ b/FilteringDashboards-Dates/index.html
@@ -39,7 +39,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
     
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
         //set this to your server url

--- a/FilteringDataObjects/client/index.html
+++ b/FilteringDataObjects/client/index.html
@@ -14,7 +14,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>    
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
     <script type="text/javascript">
 
         //set this to your server url

--- a/FilteringDataObjects/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/FilteringDataObjects/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
-    <PackageReference Include="Reveal.Sdk.Data.Microsoft.SqlServer" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
+    <PackageReference Include="Reveal.Sdk.Data.Microsoft.SqlServer" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/FilteringDataObjects/server/nodejs-js/package-lock.json
+++ b/FilteringDataObjects/server/nodejs-js/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       }
     },
     "node_modules/@types/node": {

--- a/FilteringDataObjects/server/nodejs-js/package.json
+++ b/FilteringDataObjects/server/nodejs-js/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   }
 }

--- a/FilteringDataObjects/server/nodejs-ts/package-lock.json
+++ b/FilteringDataObjects/server/nodejs-ts/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/FilteringDataObjects/server/nodejs-ts/package.json
+++ b/FilteringDataObjects/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/FilteringDataObjects/server/spring-boot-jersey/pom.xml
+++ b/FilteringDataObjects/server/spring-boot-jersey/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.infragistics.reveal.sdk</groupId>
 			<artifactId>reveal-sdk</artifactId>
-			<version>1.7.2</version>
+			<version>1.8.3</version>
 		</dependency>
 		
 	</dependencies>

--- a/FormattingFields/client/index.html
+++ b/FormattingFields/client/index.html
@@ -28,7 +28,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
     
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
 

--- a/FormattingFields/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/FormattingFields/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/FormattingFields/server/nodejs/package-lock.json
+++ b/FormattingFields/server/nodejs/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       }
     },
     "node_modules/@types/node": {

--- a/FormattingFields/server/nodejs/package.json
+++ b/FormattingFields/server/nodejs/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   }
 }

--- a/FormattingFields/server/spring-boot-jersey/pom.xml
+++ b/FormattingFields/server/spring-boot-jersey/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.infragistics.reveal.sdk</groupId>
 			<artifactId>reveal-sdk</artifactId>
-			<version>1.7.2</version>
+			<version>1.8.3</version>
 		</dependency>
 		
 	</dependencies>

--- a/LinkingDashboards-UI/server/nodejs-ts/package-lock.json
+++ b/LinkingDashboards-UI/server/nodejs-ts/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/LinkingDashboards-UI/server/nodejs-ts/package.json
+++ b/LinkingDashboards-UI/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/LinkingDashboards-UI/server/spring-boot-jersey/pom.xml
+++ b/LinkingDashboards-UI/server/spring-boot-jersey/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.infragistics.reveal.sdk</groupId>
 			<artifactId>reveal-sdk</artifactId>
-			<version>1.7.2</version>
+			<version>1.8.3</version>
 		</dependency>
 		
 	</dependencies>

--- a/LinkingDashboards/client/index.html
+++ b/LinkingDashboards/client/index.html
@@ -22,7 +22,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
     
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
         //set this to your server url

--- a/LinkingDashboards/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/LinkingDashboards/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/LoadingDashboards-Blob/client/index.html
+++ b/LoadingDashboards-Blob/client/index.html
@@ -22,7 +22,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
     
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
         //set this to your server url

--- a/LoadingDashboards-Blob/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/LoadingDashboards-Blob/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/LoadingDashboards-Blob/server/nodejs-js/package-lock.json
+++ b/LoadingDashboards-Blob/server/nodejs-js/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       }
     },
     "node_modules/@types/node": {

--- a/LoadingDashboards-Blob/server/nodejs-js/package.json
+++ b/LoadingDashboards-Blob/server/nodejs-js/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   }
 }

--- a/LoadingDashboards-Blob/server/nodejs-ts/package-lock.json
+++ b/LoadingDashboards-Blob/server/nodejs-ts/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/LoadingDashboards-Blob/server/nodejs-ts/package.json
+++ b/LoadingDashboards-Blob/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/LoadingDashboards-File/client/index.html
+++ b/LoadingDashboards-File/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
         

--- a/LoadingDashboards-File/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/LoadingDashboards-File/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/LoadingDashboards-File/server/nodejs-js/package-lock.json
+++ b/LoadingDashboards-File/server/nodejs-js/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       }
     },
     "node_modules/@types/node": {

--- a/LoadingDashboards-File/server/nodejs-js/package.json
+++ b/LoadingDashboards-File/server/nodejs-js/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   }
 }

--- a/LoadingDashboards-File/server/nodejs-ts/package-lock.json
+++ b/LoadingDashboards-File/server/nodejs-ts/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/LoadingDashboards-File/server/nodejs-ts/package.json
+++ b/LoadingDashboards-File/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/LoadingDashboards-File/server/spring-boot-jersey/pom.xml
+++ b/LoadingDashboards-File/server/spring-boot-jersey/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.infragistics.reveal.sdk</groupId>
 			<artifactId>reveal-sdk</artifactId>
-			<version>1.7.2</version>
+			<version>1.8.3</version>
 		</dependency>
 		
 	</dependencies>

--- a/LoadingDashboards-FileStream/client/index.html
+++ b/LoadingDashboards-FileStream/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         

--- a/LoadingDashboards-FileStream/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/LoadingDashboards-FileStream/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/LoadingDashboards-Json/client/index.html
+++ b/LoadingDashboards-Json/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         

--- a/LoadingDashboards-Json/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/LoadingDashboards-Json/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/LoadingDashboards-Resource/client/index.html
+++ b/LoadingDashboards-Resource/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         

--- a/LoadingDashboards-Resource/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/LoadingDashboards-Resource/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/LoadingDashboards-Resource/server/spring-boot-jersey/pom.xml
+++ b/LoadingDashboards-Resource/server/spring-boot-jersey/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.infragistics.reveal.sdk</groupId>
 			<artifactId>reveal-sdk</artifactId>
-			<version>1.7.2</version>
+			<version>1.8.3</version>
 		</dependency>
 		
 	</dependencies>

--- a/LoadingDashboards/client/index.html
+++ b/LoadingDashboards/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
         

--- a/LoadingDashboards/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/LoadingDashboards/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 

--- a/LoadingDashboards/server/nodejs-js/package-lock.json
+++ b/LoadingDashboards/server/nodejs-js/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       }
     },
     "node_modules/@types/node": {

--- a/LoadingDashboards/server/nodejs-js/package.json
+++ b/LoadingDashboards/server/nodejs-js/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   }
 }

--- a/LoadingDashboards/server/nodejs-ts/package-lock.json
+++ b/LoadingDashboards/server/nodejs-ts/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/LoadingDashboards/server/nodejs-ts/package.json
+++ b/LoadingDashboards/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/LocalizingDashboards/index.html
+++ b/LocalizingDashboards/index.html
@@ -30,7 +30,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
     
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-    <script src="https://dl.revealbi.io/reveal/libs/1.6.4/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
 

--- a/ObfuscateConnectionData/client/index.html
+++ b/ObfuscateConnectionData/client/index.html
@@ -15,7 +15,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">
         $.ig.RevealSdkSettings.setBaseUrl("http://localhost:5111/");

--- a/ObfuscateConnectionData/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/ObfuscateConnectionData/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/ObfuscateConnectionData/server/spring-boot-jersey/pom.xml
+++ b/ObfuscateConnectionData/server/spring-boot-jersey/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.infragistics.reveal.sdk</groupId>
 			<artifactId>reveal-sdk</artifactId>
-			<version>1.7.2</version>
+			<version>1.8.3</version>
 		</dependency>
 		
 	</dependencies>

--- a/SavingDashboards-Client/client/index.html
+++ b/SavingDashboards-Client/client/index.html
@@ -22,7 +22,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
     
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
         //set this to your server url

--- a/SavingDashboards-Client/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/SavingDashboards-Client/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/SavingDashboards-Client/server/nodejs-js/package-lock.json
+++ b/SavingDashboards-Client/server/nodejs-js/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       }
     },
     "node_modules/@types/node": {

--- a/SavingDashboards-Client/server/nodejs-js/package.json
+++ b/SavingDashboards-Client/server/nodejs-js/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   }
 }

--- a/SavingDashboards-Client/server/nodejs-ts/package-lock.json
+++ b/SavingDashboards-Client/server/nodejs-ts/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/SavingDashboards-Client/server/nodejs-ts/package.json
+++ b/SavingDashboards-Client/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/SavingDashboards-Server/client/index.html
+++ b/SavingDashboards-Server/client/index.html
@@ -22,7 +22,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
     
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
         //set this to your server url

--- a/SavingDashboards-Server/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/SavingDashboards-Server/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/SavingDashboards-Server/server/nodejs-js/package-lock.json
+++ b/SavingDashboards-Server/server/nodejs-js/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       }
     },
     "node_modules/@types/node": {

--- a/SavingDashboards-Server/server/nodejs-js/package.json
+++ b/SavingDashboards-Server/server/nodejs-js/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   }
 }

--- a/SavingDashboards-Server/server/nodejs-ts/package-lock.json
+++ b/SavingDashboards-Server/server/nodejs-ts/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "reveal-sdk-node": "^1.7.2"
+        "reveal-sdk-node": "^1.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",

--- a/SavingDashboards-Server/server/nodejs-ts/package.json
+++ b/SavingDashboards-Server/server/nodejs-ts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "reveal-sdk-node": "^1.7.2"
+    "reveal-sdk-node": "^1.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/SingleVisualizationMode/index.html
+++ b/SingleVisualizationMode/index.html
@@ -66,7 +66,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
 

--- a/ThemingDashboards/index.html
+++ b/ThemingDashboards/index.html
@@ -22,7 +22,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" ></script>
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js" ></script>    
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.2/infragistics.reveal.js"></script>   
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>   
 
     <script type="text/javascript">        
         //set this to your server url

--- a/Tooltips/index.html
+++ b/Tooltips/index.html
@@ -32,7 +32,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.6/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
 

--- a/UnderlyingData/index.html
+++ b/UnderlyingData/index.html
@@ -104,7 +104,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-    <script src="https://dl.revealbi.io/reveal/libs/1.8.0/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@revealbi/dom@0.2.25/index.umd.min.js"></script>
 
 

--- a/UserContext - Cookies/client/index.html
+++ b/UserContext - Cookies/client/index.html
@@ -28,7 +28,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-    <script src="https://dl.revealbi.io/reveal/libs/1.6.4/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
 

--- a/UserContext - Cookies/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
+++ b/UserContext - Cookies/server/aspnet/RevealSdk.Server/RevealSdk.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.7.2" />
+    <PackageReference Include="Reveal.Sdk.AspNetCore" Version="1.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 

--- a/VisualizationDataPointClicked/index.html
+++ b/VisualizationDataPointClicked/index.html
@@ -33,7 +33,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-    <script src="https://dl.revealbi.io/reveal/libs/1.7.6/infragistics.reveal.js"></script>
+    <script src="https://dl.revealbi.io/reveal/libs/1.8.3/infragistics.reveal.js"></script>
 
     <script type="text/javascript">
 


### PR DESCRIPTION
Updates the Reveal SDK version in multiple HTML files to the latest version, 1.8.3. This ensures that all dashboards are using the most up-to-date features and fixes.